### PR TITLE
add Value methods

### DIFF
--- a/lazy.go
+++ b/lazy.go
@@ -19,11 +19,15 @@
 // I'm lazy and we have generics, so why not ab^H^Huse them?
 package lazy
 
-import "sync"
+import (
+	"sync"
+	"sync/atomic"
+)
 
 type T[V any] struct {
-	once sync.Once
-	v    V
+	done uint32     // set to 1 after Get is called
+	m    sync.Mutex // guards v while writing
+	v    V          // underlying value
 }
 
 // Get calls fn if and only if it is being called for the first
@@ -31,17 +35,37 @@ type T[V any] struct {
 //
 // Subsequent invocations of Get return the same result.
 //
-// It has the same semantics as sync.Once because it's a wrapper
-// around sync.Once.
+// It has the same semantics as [sync.Once].
 func (t *T[V]) Get(fn func() V) V {
-	t.once.Do(func() { t.v = fn() })
+	if atomic.LoadUint32(&t.done) == 0 {
+		t.m.Lock()
+		defer t.m.Unlock()
+
+		if t.done == 0 {
+			defer atomic.StoreUint32(&t.done, 1)
+			t.v = fn()
+		}
+	}
 	return t.v
 }
 
+// Value returns the cached value, if set.
+func (t *T[V]) Value() (V, bool) {
+	if atomic.LoadUint32(&t.done) != 0 {
+		return t.v, true
+	}
+
+	t.m.Lock()
+	defer t.m.Unlock()
+
+	return t.v, t.done != 0
+}
+
 type E[V any] struct {
-	once sync.Once
-	v    V
-	err  error
+	done uint32     // set to 1 after Get is called
+	m    sync.Mutex // guards v, err while writing
+	v    V          // underlying value
+	err  error      // underlying value
 }
 
 // Get calls fn if and only if it is being called for the first
@@ -49,13 +73,30 @@ type E[V any] struct {
 //
 // Subsequent invocations of Get return the same result.
 //
-// It has the same semantics as sync.Once because it's a wrapper
-// around sync.Once.
+// It has the same semantics as [sync.Once].
 func (t *E[V]) Get(fn func() (V, error)) (V, error) {
-	t.once.Do(func() {
-		t.v, t.err = fn()
-	})
+	if atomic.LoadUint32(&t.done) == 0 {
+		t.m.Lock()
+		defer t.m.Unlock()
+
+		if t.done == 0 {
+			defer atomic.StoreUint32(&t.done, 1)
+			t.v, t.err = fn()
+		}
+	}
 	return t.v, t.err
+}
+
+// Value returns the cached value, if set.
+func (t *E[V]) Value() (V, bool) {
+	if atomic.LoadUint32(&t.done) != 0 {
+		return t.v, true
+	}
+
+	t.m.Lock()
+	defer t.m.Unlock()
+
+	return t.v, t.done != 0
 }
 
 // Must returns panics if err != nil and returns t otherwise.

--- a/lazy_test.go
+++ b/lazy_test.go
@@ -17,6 +17,19 @@ func TestT(t *testing.T) {
 	}
 }
 
+func TestTValue(t *testing.T) {
+	var v T[int]
+	got, ok := v.Value()
+	if got != 0 || ok {
+		t.Fatalf("expected (%d, %t), got (%d, %t)", 0, false, got, ok)
+	}
+	v.Get(func() int { return 42 })
+	got, ok = v.Value()
+	if got != 42 || !ok {
+		t.Fatalf("expected (%d, %t), got (%d, %t)", 42, true, got, ok)
+	}
+}
+
 func TestE(t *testing.T) {
 	var v E[int]
 	err42 := errors.New("42!")
@@ -30,5 +43,20 @@ func TestE(t *testing.T) {
 		if err != err42 {
 			t.Fatalf("expected %v, got %v", err42, err)
 		}
+	}
+}
+
+func TestEValue(t *testing.T) {
+	var v E[int]
+	got, ok := v.Value()
+	if got != 0 || ok {
+		t.Fatalf("expected (%d, %t), got (%d, %t)", 0, false, got, ok)
+	}
+	v.Get(func() (int, error) {
+		return 42, nil
+	})
+	got, ok = v.Value()
+	if got != 42 || !ok {
+		t.Fatalf("expected (%d, %t), got (%d, %t)", 42, true, got, ok)
 	}
 }

--- a/once_test.go
+++ b/once_test.go
@@ -1,0 +1,72 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package lazy
+
+import (
+	"testing"
+)
+
+type one int
+
+func (o *one) Increment() {
+	*o++
+}
+
+func run(t *testing.T, v *T[int], o *one, c chan bool) {
+	v.Get(func() int {
+		o.Increment()
+		return 0
+	})
+	if v := *o; v != 1 {
+		t.Errorf("once failed inside run: %d is not 1", v)
+	}
+	c <- true
+}
+
+func TestTRace(t *testing.T) {
+	o := new(one)
+	var v T[int]
+	c := make(chan bool)
+	const N = 10
+	for i := 0; i < N; i++ {
+		go run(t, &v, o, c)
+	}
+	for i := 0; i < N; i++ {
+		<-c
+	}
+	if *o != 1 {
+		t.Errorf("once failed outside run: %d is not 1", *o)
+	}
+}
+
+func TestTPanic(t *testing.T) {
+	var v T[int]
+	func() {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Fatalf("T.Get did not panic")
+			}
+		}()
+		v.Get(func() int {
+			panic("failed")
+		})
+	}()
+
+	v.Get(func() int {
+		t.Fatalf("Once.Do called twice")
+		return 0
+	})
+}
+
+func BenchmarkOnce(b *testing.B) {
+	var v T[int]
+	b.RunParallel(func(pb *testing.PB) {
+		for i := 0; pb.Next(); i++ {
+			v.Get(func() int {
+				return i
+			})
+		}
+	})
+}


### PR DESCRIPTION
These are useful when T or E are used for resources that must be closed. For example:

    type T struct {
	db   *sql.DB
	stmt lazy.T[*db.Stmt]
    }

    func (t *T) doThing() error {
	stmt, err := t.stmt.Get(func() (*sql.Stmt, error) {
	    return t.db.Prepare(...)
	})
	if err != nil { ...  }
	...
    }

    func (t *T) Close() error{
	if s, ok := t.stmt.Value(); ok {
	    s.Close()
	}
	return t.db.Close()
    }

Signed-off-by: Eric Lagergren <elagergren@spideroak-inc.com>